### PR TITLE
fix: NVME boot is only considered when network disconnected

### DIFF
--- a/artifacts/u-boot/patches/0002-rpi-add-NVMe-to-boot-order.patch
+++ b/artifacts/u-boot/patches/0002-rpi-add-NVMe-to-boot-order.patch
@@ -1,25 +1,25 @@
-From 0c4e4f9cce2bd329a2c607c28fc770586a503ab9 Mon Sep 17 00:00:00 2001
-From: Tom Plant <tom@tplant.com.au>
-Date: Sun, 3 Dec 2023 09:27:07 +0000
+From f53b9a545132686b0286ce166203a57935502dbc Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 29 Dec 2020 23:34:52 +0100
 Subject: [PATCH] rpi: add NVMe to boot order
 
 The Compute Module 4 I/O Board can support a NVMe. Add NVMe to the boot
 order.
 
-Signed-off-by: Tom Plant <tom@tplant.com.au>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
  board/raspberrypi/rpi/rpi.env | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
-index 30228285ed..0226e31680 100644
+index 30228285ed..89f6c5a839 100644
 --- a/board/raspberrypi/rpi/rpi.env
 +++ b/board/raspberrypi/rpi/rpi.env
 @@ -74,4 +74,4 @@ pxefile_addr_r=0x02500000
  fdt_addr_r=0x02600000
  ramdisk_addr_r=0x02700000
-
+ 
 -boot_targets=mmc usb pxe dhcp
-+boot_targets=mmc usb pxe dhcp nvme
---
-2.39.2
++boot_targets=mmc nvme usb pxe dhcp
+-- 
+2.43.0


### PR DESCRIPTION
Fixes #12 

Signed-off-by: Matthias Riegler <matthias.riegler@ankorstore.com>