### PR TITLE
feat: enable watchdog device in firmware by default

### DIFF
--- a/installers/rpi_generic/src/config.txt
+++ b/installers/rpi_generic/src/config.txt
@@ -17,3 +17,5 @@ enable_uart=1
 dtoverlay=disable-bt
 # Disable Wireless Lan.
 dtoverlay=disable-wifi
+# Enable watchdog
+dtparam=watchdog=on


### PR DESCRIPTION
In https://github.com/siderolabs/pkgs/pull/1134 the driver enabled in the talos kernel.

However, this does nothing unless its also enabled in the firmware.

I tested with `configTxtAppend: dtparam=watchdog=on` which works. The device is created, and when enabled in talos the watchdog is running.

related: https://github.com/siderolabs/talos/issues/10099