### PR TITLE
feat: revert enable watchdog device in firmware by default

### DIFF
--- a/installers/rpi_generic/src/config.txt
+++ b/installers/rpi_generic/src/config.txt
@@ -17,5 +17,3 @@ enable_uart=1
 dtoverlay=disable-bt
 # Disable Wireless Lan.
 dtoverlay=disable-wifi
-# Enable watchdog
-dtparam=watchdog=on


### PR DESCRIPTION
This reverts commit e113e8b12749ca309903022fa6eafe60d14a7919.

See #38