### PR TITLE
Add support for the RevolutionPi

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+
+## Overview
+
+This document contains a list of maintainers in this repo. For now, you become a maintainer if you submit a PR that adds a new board. You are responsible for testing the overlay on the board you added.
+
+## Current Maintainers
+
+| Overlay Name  | Board                | PR                                                         | Maintainer                       | GitHub ID                           |
+| ------------- | -------------------- | ---------------------------------------------------------- | -------------------------------- | ----------------------------------- |
+| rpi_generic   | Raspberry Pi Generic | [#1](https://github.com/siderolabs/sbc-raspberrypi/pull/1) | TBD (Initial PR moved from pkgs) |
+| revpi_generic | RevolutionPi         | [#44](https://github.com/siderolabs/sbc-rockchip/pull/44)  | Martin Schuessler                | [c0ffee](https://github.com/c0ffee) |

--- a/Pkgfile
+++ b/Pkgfile
@@ -12,5 +12,11 @@ vars:
   uboot_version: 2024.07
   uboot_sha256: f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f
   uboot_sha512: 678f44e2b9132140f0bf05c637e57e638c73c278611037a41824b3ebff2131af4dec0163da4664bb2e5c4fd8034ba8c95b93b57f7aa9f4c045da322d87c3b5e9
+
+  # renovate: datasource=github-tags depName=revolutionpi/linux
+  revpi_kernel_version: v6.6.46-rt39-revpi6
+  revpi_kernel_sha256: 6f5e6b8c3dbc48981750157526a367f8c84f6ca6ef94093e908c1cf52d776fda
+  revpi_kernel_sha512: 481a061aaa6199c6f2a30c3a5bc4133265840d32f53092af33f503b18107044420f4f753819a1f17c57244edf45180332023b8f263719a152527073ebe05d7b0
+
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/sbc-raspberrypi

--- a/artifacts/revpi_generic/revpi-firmware/pkg.yaml
+++ b/artifacts/revpi_generic/revpi-firmware/pkg.yaml
@@ -1,0 +1,31 @@
+name: revpi-firmware
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      ARCH: arm64
+  - sources:
+      - url: https://github.com/revolutionpi/linux/archive/refs/tags/{{ .revpi_kernel_version }}.tar.gz
+        destination: revpi-kernel.tar.gz
+        sha256: "{{ .revpi_kernel_sha256 }}"
+        sha512: "{{ .revpi_kernel_sha512 }}"
+    prepare:
+      - |
+        mkdir -p /src
+        tar xf revpi-kernel.tar.gz --strip-components=1 -C /src
+
+        cd /src
+        make revpi-v8_defconfig
+    build:
+      - |
+        cd /src
+        make -j $(nproc) dtbs
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/firmware/revpi_generic/boot/overlays
+        cp -av /src/arch/arm64/boot/dts/overlays/*.dtbo /rootfs/artifacts/arm64/firmware/revpi_generic/boot/overlays
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -2,7 +2,10 @@ name: sbc-raspberrypi
 variant: scratch
 dependencies:
   - stage: rpi_generic
+  - stage: revpi_generic
   - stage: raspberrypi-firmware
+  - stage: revpi-firmware
+    platform: linux/arm64
   - stage: u-boot
     platform: linux/arm64
   - stage: profiles

--- a/installers/revpi_generic/pkg.yaml
+++ b/installers/revpi_generic/pkg.yaml
@@ -1,0 +1,33 @@
+name: revpi_generic
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /tmp/go
+    network: default
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      - |
+        cd /pkg/src
+        go mod download
+  - env:
+      GOPATH: /tmp/go
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    build:
+      - |
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./revpi_generic .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp -p /pkg/src/revpi_generic /rootfs/installers/revpi_generic
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/revpi_generic/src/config.txt
+++ b/installers/revpi_generic/src/config.txt
@@ -1,0 +1,20 @@
+# See https://www.raspberrypi.com/documentation/computers/configuration.html
+# Reduce GPU memory to give more to CPU.
+gpu_mem=32
+# Enable maximum compatibility on both HDMI ports;
+# only the one closest to the power/USB-C port will work in practice.
+hdmi_safe:0=1
+hdmi_safe:1=1
+# Load U-Boot.
+kernel=u-boot.bin
+# Forces the kernel loading system to assume a 64-bit kernel.
+arm_64bit=1
+# Run as fast as firmware / board allows.
+arm_boost=1
+# Enable the primary/console UART.
+enable_uart=1
+# Disable Bluetooth.
+dtoverlay=disable-bt
+# Disable Wireless Lan.
+dtoverlay=disable-wifi
+

--- a/installers/revpi_generic/src/go.mod
+++ b/installers/revpi_generic/src/go.mod
@@ -1,0 +1,10 @@
+module rpi_generic
+
+go 1.24.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.4
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/revpi_generic/src/go.sum
+++ b/installers/revpi_generic/src/go.sum
@@ -1,0 +1,8 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.9.4 h1:ReKkU5gaf5h/cZde3ME45hREgOEWODTJYfBFeMhZGkA=
+github.com/siderolabs/talos/pkg/machinery v1.9.4/go.mod h1:yLkJ5ZvIpshDRhUVWjuSyTN6YAQiusSJF4/zj2/XfpY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/revpi_generic/src/main.go
+++ b/installers/revpi_generic/src/main.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+)
+
+//go:embed config.txt
+var configTxt []byte
+
+func main() {
+	adapter.Execute(&RpiInstaller{})
+}
+
+type RpiInstaller struct{}
+
+type rpiOptions struct {
+	ConfigTxt       string `yaml:"configTxt,omitempty"`
+	ConfigTxtAppend string `yaml:"configTxtAppend,omitempty"`
+}
+
+func (i *RpiInstaller) GetOptions(extra rpiOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: "revpi_generic",
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyAMA0,115200",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+	}, nil
+}
+
+func (i *RpiInstaller) Install(options overlay.InstallOptions[rpiOptions]) error {
+	err := copy.Dir(filepath.Join(options.ArtifactsPath, "arm64/firmware/boot"), filepath.Join(options.MountPrefix, "/boot/EFI"))
+	if err != nil {
+		return err
+	}
+
+	err = copy.Dir(filepath.Join(options.ArtifactsPath, "arm64/firmware/revpi_generic/boot"), filepath.Join(options.MountPrefix, "/boot/EFI"))
+	if err != nil {
+		return err
+	}
+
+	err = copy.File(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rpi_generic/u-boot.bin"), filepath.Join(options.MountPrefix, "/boot/EFI/u-boot.bin"))
+	if err != nil {
+		return err
+	}
+
+	if options.ExtraOptions.ConfigTxt != "" {
+		configTxt = []byte(options.ExtraOptions.ConfigTxt)
+	}
+
+	configTxt = append(configTxt, []byte("\n"+options.ExtraOptions.ConfigTxtAppend)...)
+
+	return os.WriteFile(filepath.Join(options.MountPrefix, "/boot/EFI/config.txt"), configTxt, 0o644)
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -3,3 +3,5 @@ variant: scratch
 finalize:
   - from: /pkg/rpi_generic
     to: /rootfs/profiles
+  - from: /pkg/revpi_generic
+    to: /rootfs/profiles

--- a/profiles/revpi_generic/revpi_generic.yaml
+++ b/profiles/revpi_generic/revpi_generic.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw


### PR DESCRIPTION
The company Kunbus builds devices based on the RaspberryPi CM modules(https://revolutionpi.com/).

They use a custom baseboard to support additional peripherals. Besides they change the mac address of the integrated phy on the CM module to a Kunbus mac address printed on the front of the device. First step to support at least the mac address is adding their custom device trees. We will need an extra extension to set then mac address, in their own debian fork they use udev for this. 
To support any other peripherals like the second ethernet device kernel changes are needed which is not support as far as i see for know right? 