### PR TITLE
fix: use grub as bootloader for SBCs

### DIFF
--- a/profiles/revpi_generic/revpi_generic.yaml
+++ b/profiles/revpi_generic/revpi_generic.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub

--- a/profiles/rpi_generic/rpi_generic.yaml
+++ b/profiles/rpi_generic/rpi_generic.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub


### PR DESCRIPTION
Part of: https://github.com/siderolabs/talos/issues/10859