### PR TITLE
chore: bump deps to support raspberry pi 5

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,14 +4,14 @@ format: v1alpha2
 
 vars:
   # renovate: datasource=github-tags depName=raspberrypi/firmware
-  raspberrypi_firmware_version: 1.20250305
-  raspberrypi_firmware_sha256: 4981021b82f600f450d64d9b82034dc603bf5429889a3947b2863e01992a343c
-  raspberrypi_firmware_sha512: 936025f6fe20cd3a4e5da636bb288c50bb78ca1e1df35cd3605d2936b82d79388f30163e1a4dcdb8dd47db05bf6c44916189f01e66a3f01511dc6963502afc46
+  raspberrypi_firmware_version: 1.20250915
+  raspberrypi_firmware_sha256: 55a5d58c59bf7171562f1f1289c638e97e2b8d90374084887bfe5fc83e57cb1d
+  raspberrypi_firmware_sha512: 33120c901c59fbcd267427dce5fd8f174d32476bfae76744697f6729151d66054c6f0bd54f29c3b715c1492a52724fe2973a6adbf31cfb79f1c82dd94983cf77
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=u-boot/u-boot
-  uboot_version: 2024.07
-  uboot_sha256: f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f
-  uboot_sha512: 678f44e2b9132140f0bf05c637e57e638c73c278611037a41824b3ebff2131af4dec0163da4664bb2e5c4fd8034ba8c95b93b57f7aa9f4c045da322d87c3b5e9
+  uboot_version: 2026.01-rc2
+  uboot_sha256: 55a5e5783c1a0f0d5cfcd3a3529a81ccbc5ac182b3f6d25ac38dad9585329e31
+  uboot_sha512: 404568a8ecf00145e154ee2856fb79a68ea9ce30466be12f8836ea6f6440f523abe438b78cb833a7be16865f5063a021be2aef778900a7c75952515788608010
 
   # renovate: datasource=github-tags depName=revolutionpi/linux
   revpi_kernel_version: v6.6.46-rt39-revpi6

--- a/artifacts/u-boot/patches/0008-enable-nvme-and-fixup-efi-boot.patch
+++ b/artifacts/u-boot/patches/0008-enable-nvme-and-fixup-efi-boot.patch
@@ -12,10 +12,11 @@ diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
 index f9dade18f6..f2394e4a52 100644
 --- a/configs/rpi_arm64_defconfig
 +++ b/configs/rpi_arm64_defconfig
-@@ -57,3 +57,19 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -63,4 +63,20 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
+ # CONFIG_HEXDUMP is not set
 +# Enable NVME
 +CONFIG_NVME_PCI=y
 +CONFIG_CMD_NVME=y


### PR DESCRIPTION
Linux kernel 6.17 mainlined support for Raspberry Pi 5 dts and RP1 drivers, and [u-boot 2026.01-rc1 merges upstream 6.17 dts](https://github.com/u-boot/u-boot/tree/v2026.01-rc1/dts/upstream/src/arm64/broadcom). Therefore we can expect RPi5 might work for Talos 1.12.0-alpha.2 (which includes 6.17 based kernel) or later, with newer u-boot dependencies, without custom overlays.

While Linux 6.17 is not expected to be LTS, u-boot 2026.01-rc1 is still RC, and Talos 1.12 is still in alpha phase, I don't expect this PR to be merged as is, but hope to be a testbed if would it work before the stable versions are available.
