### PR TITLE
fix: disable UART for Raspberry Pi 5

### DIFF
--- a/installers/rpi_generic/src/config.txt
+++ b/installers/rpi_generic/src/config.txt
@@ -17,3 +17,6 @@ enable_uart=1
 dtoverlay=disable-bt
 # Disable Wireless Lan.
 dtoverlay=disable-wifi
+# Disable UART for Raspberry Pi 5 to avoid U-boot compatibility issue.
+[pi5]
+enable_uart=0


### PR DESCRIPTION
Added configuration to disable UART for Raspberry Pi 5 to avoid U-boot compatibility issue.

ref) https://bugzilla.opensuse.org/show_bug.cgi?id=1251192#c24 and https://github.com/siderolabs/sbc-raspberrypi/issues/23#issuecomment-3527204823