### PR TITLE
fix: ensure we apply [all] filters to config 

### DIFF
--- a/installers/rpi_generic/src/config.txt
+++ b/installers/rpi_generic/src/config.txt
@@ -20,3 +20,4 @@ dtoverlay=disable-wifi
 # Disable UART for Raspberry Pi 5 to avoid U-boot compatibility issue.
 [pi5]
 enable_uart=0
+[all]


### PR DESCRIPTION
Unless we have a [all], all entries added using configTxtAppend will only affect pi5s.
 https://www.raspberrypi.com/documentation/computers/config_txt.html#the-all-filter