### PR TITLE
feat: add DTB build for Raspberry Pi 5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,6 +67,12 @@
             "matchPackageNames": [
                 "raspberrypi/firmware"
             ]
+        },
+        {
+            "versioning": "regex:^stable_(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$",
+            "matchPackageNames": [
+                "raspberrypi/linux"
+            ]
         }
     ],
     "separateMajorMinor": false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-20T20:04:05Z by kres 1ffefb6.
+# Generated on 2026-02-17T10:34:39Z by kres 6458cfd.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -55,7 +55,7 @@ jobs:
           done
         continue-on-error: true
       - name: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version: v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # version: v6.0.2
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -74,7 +74,7 @@ jobs:
           make
       - name: Login to registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # version: v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # version: v3.7.0
         with:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -34,3 +34,6 @@ spec:
     - matchPackageNames:
         - raspberrypi/firmware
       versioning: 'regex:^\d+\.(?<major>\d{4})(?<minor>\d{2})(?<patch>\d{2})$'
+    - matchPackageNames:
+        - raspberrypi/linux
+      versioning: 'regex:^stable_(?<major>\d{4})(?<minor>\d{2})(?<patch>\d{2})$'

--- a/Pkgfile
+++ b/Pkgfile
@@ -9,9 +9,14 @@ vars:
   raspberrypi_firmware_sha512: 33120c901c59fbcd267427dce5fd8f174d32476bfae76744697f6729151d66054c6f0bd54f29c3b715c1492a52724fe2973a6adbf31cfb79f1c82dd94983cf77
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=u-boot/u-boot
-  uboot_version: 2026.04-rc1
-  uboot_sha256: f31508342d3eada4f952e459bf108c470ca1cda3357ce216446392cbdb31392a
-  uboot_sha512: 4011cd8aecd91f981d26218f3d568f5d2b3f7d8c639a0fa61a56f5e40e21376bc73c8bfd5757a08150d58913f038bd36f9769726f8cfdd9490d280b56762eab5
+  uboot_version: 2026.01
+  uboot_sha256: b60d5865cefdbc75da8da4156c56c458e00de75a49b80c1a2e58a96e30ad0d54
+  uboot_sha512: b1f988a497c77da60faf89ed33034e9ae58c4cd7f208e5ce451f1372e13540a66289bee4f08ca2f68f105d73f1ceae058b1f713db549edbcc885d9c66bdc4f8b
+
+  # renovate: datasource=github-tags depName=raspberrypi/linux
+  raspberrypi_kernel_version: stable_20250428
+  raspberrypi_kernel_sha256: c95906cfbc7808de5860c6d86537bea22e3501f600a5209de59a86cb436886f6
+  raspberrypi_kernel_sha512: 0ed5d490c491e590b5980dccf6fcac0dd3c47accbfacd40d91507c12801cff34fa6a1c68991c8a6c57bb259c909121414766f35a0b11c4bd5d62c3e11d710839
 
   # renovate: datasource=github-tags depName=revolutionpi/linux
   revpi_kernel_version: v6.6.46-rt39-revpi7

--- a/artifacts/dtb/raspberrypi/Makefile
+++ b/artifacts/dtb/raspberrypi/Makefile
@@ -1,0 +1,29 @@
+OBS_BASE_URL := https://build.opensuse.org/public/source/hardware:boot/raspberrypi-firmware-dt
+PATCH_DIR := patches
+OVERLAY_DIR := overlays
+WORK_DIR := .sync
+SPEC_FILE := $(WORK_DIR)/raspberrypi-firmware-dt.spec
+
+.PHONY: sync clean
+
+sync:
+	@set -eu -o pipefail; \
+	trap 'rm -rf "$(WORK_DIR)"' EXIT; \
+	mkdir -p "$(PATCH_DIR)" "$(OVERLAY_DIR)" "$(WORK_DIR)"; \
+	curl -fsSL "$(OBS_BASE_URL)/raspberrypi-firmware-dt.spec" -o "$(SPEC_FILE)"; \
+	rm -f "$(PATCH_DIR)"/*.patch "$(OVERLAY_DIR)"/*.dts; \
+	sed -nE 's/^Patch([0-9]+):[[:space:]]+(.+)$$/\1|\2/p' "$(SPEC_FILE)" \
+		| while IFS='|' read -r idx file; do \
+			[ -n "$$file" ] || continue; \
+			printf -v patch_idx "%04d" "$$idx"; \
+			curl -fsSL "$(OBS_BASE_URL)/$$file" \
+				-o "$(PATCH_DIR)/$$patch_idx-$$file"; \
+		done; \
+	sed -nE 's/^Source[0-9]+:[[:space:]]+(.+\.dts)$$/\1/p' "$(SPEC_FILE)" \
+		| while IFS= read -r file; do \
+			[ -n "$$file" ] || continue; \
+			curl -fsSL "$(OBS_BASE_URL)/$$file" -o "$(OVERLAY_DIR)/$$file"; \
+		done;
+
+clean:
+	rm -rf "$(WORK_DIR)"

--- a/artifacts/dtb/raspberrypi/README
+++ b/artifacts/dtb/raspberrypi/README
@@ -1,0 +1,10 @@
+Run `make sync` to synchronize:
+
+- `patches/*.patch`
+- `overlays/*.dts`
+
+The sync source is the openSUSE `raspberrypi-firmware-dt` SRPM.
+(https://build.opensuse.org/package/show/hardware:boot/raspberrypi-firmware-dt)
+
+These patches and overlays are part of (and derived from) the Linux kernel, covered by the GPLv2 license.
+The patches are downloaded without modifications from the SUSE repository.

--- a/artifacts/dtb/raspberrypi/overlays/disable-v3d-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/disable-v3d-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&v3d>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/artifacts/dtb/raspberrypi/overlays/disable-vc4-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/disable-vc4-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&vc4>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/artifacts/dtb/raspberrypi/overlays/enable-bt-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/enable-bt-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&bt>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/artifacts/dtb/raspberrypi/overlays/fixup-blconfig-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/fixup-blconfig-overlay.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&blconfig>;
+		__overlay__ {
+			reg = <0x00  0x3fd16cc0 0x00 0x38>;
+		};
+	};
+};

--- a/artifacts/dtb/raspberrypi/overlays/smbios-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/smbios-overlay.dts
@@ -1,0 +1,31 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+
+			smbios {
+				compatible = "u-boot,sysinfo-smbios";
+				smbios {
+					system {
+						manufacturer = "raspberrypi";
+						product = "rpi";
+					};
+					baseboard {
+						manufacturer = "raspberrypi";
+						product = "rpi";
+					};
+					chassis {
+						manufacturer = "raspberrypi";
+						product = "rpi";
+					};
+				};
+			};
+		};
+	};
+};
+

--- a/artifacts/dtb/raspberrypi/overlays/uboot-bcm2835-pl011-overlay.dts
+++ b/artifacts/dtb/raspberrypi/overlays/uboot-bcm2835-pl011-overlay.dts
@@ -1,0 +1,20 @@
+/*
+ * As opposed to the upstream/downstream kernel, u-boot needs a special
+ * compatible string to access RPi, RPi2 and RPi0's serial consoles. This was
+ * removed from both upstream and downstream Linux's device-trees as there is
+ * no existing binding or use for it. While we fix this in upstream u-boot,
+ * this overlay fixes booting on those platforms.
+ */
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&uart0>;
+		__overlay__ {
+			compatible = "brcm,bcm2835-pl011", "arm,pl011", "arm,primecell";
+		};
+	};
+};

--- a/artifacts/dtb/raspberrypi/patches/0000-0001-ARM-dts-bcm2711-rpi-Reuse-bcm2836-vchiq-driver.patch
+++ b/artifacts/dtb/raspberrypi/patches/0000-0001-ARM-dts-bcm2711-rpi-Reuse-bcm2836-vchiq-driver.patch
@@ -1,0 +1,32 @@
+From 9d36eb65e475361db8751fa6a155c9bdeaa2bcdd Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Tue, 30 May 2023 09:50:53 +0300
+Subject: [PATCH] ARM: dts: bcm2711-rpi: Reuse bcm2836 vchiq driver
+
+Upstream vchiq driver don't support bcm2711, yet. Switch
+to bcm2836 implementation which is good enough to make audio
+trough 3.5mm jack working fine.
+
+This fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1209314
+
+Signed-off-by: Ivan T. Ivanov <iivanov@suse.de>
+---
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+index bd5c297..9956368 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+@@ -126,7 +126,7 @@
+ };
+ 
+ &vchiq {
+-	compatible = "brcm,bcm2711-vchiq";
++	compatible = "brcm,bcm2836-vchiq";
+ };
+ 
+ &firmwarekms {
+-- 
+2.35.3
+

--- a/artifacts/dtb/raspberrypi/patches/0001-0001-ARM-dts-bcm27xx-Use-better-name-for-spidev.patch
+++ b/artifacts/dtb/raspberrypi/patches/0001-0001-ARM-dts-bcm27xx-Use-better-name-for-spidev.patch
@@ -1,0 +1,930 @@
+From be76a8925bf12113c225317e8704c41cc9a53bfe Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Mon, 17 Jul 2023 17:38:31 +0300
+Subject: [PATCH] ARM: dts: bcm27xx: Use better name for spidev
+
+Since this patch [1] 'spidev' compatible strings can not be used to auto bind
+to spidev module. Apparently upstream don not want these to used anymore.
+
+Vendor Linux tree, from where we are getting these Device Tree files, still
+support this because it have this [2] patch.
+
+Lets follow upstream decision even if we slightly diverge from the Vendor
+Device Tree sources.
+
+[1] fffc84fd87d9 ("spi: spidev: Make probe to fail early if a spidev compatible is used")
+[2] 0dd30794bd79 ("spi: spidev: Restore loading from Device Tree")
+
+This fixes bsc#1212791 and bsc#1219094.
+
+Signed-off-by: Ivan T. Ivanov <iivanov@suse.de>
+---
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-b-plus.dts           | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-b-rev1.dts           | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-b.dts                | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dts               | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts           | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2708-rpi-zero.dts             | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2709-rpi-2-b.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-2-b.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts         | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-cm0.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts         | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts              | 4 ++--
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/rpi-rp2040-gpio-bridge.dtsi      | 2 +-
+ arch/arm/boot/dts/overlays/seeed-can-fd-hat-v1-overlay.dts  | 2 +-
+ arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts             | 6 +++---
+ arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi2-1cs-pi5-overlay.dts         | 2 +-
+ arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/spi2-2cs-pi5-overlay.dts         | 4 ++--
+ arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts             | 6 +++---
+ arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi3-1cs-pi5-overlay.dts         | 2 +-
+ arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/spi3-2cs-pi5-overlay.dts         | 4 ++--
+ arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi5-1cs-pi5-overlay.dts         | 2 +-
+ arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts             | 4 ++--
+ arch/arm/boot/dts/overlays/spi5-2cs-pi5-overlay.dts         | 4 ++--
+ arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts             | 2 +-
+ arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts             | 4 ++--
+ .../dts/overlays/waveshare-can-fd-hat-mode-a-overlay.dts    | 2 +-
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts            | 2 +-
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi           | 2 +-
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi               | 4 ++--
+ arch/arm64/boot/dts/broadcom/rp1.dtsi                       | 4 ++--
+ 44 files changed, 76 insertions(+), 76 deletions(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-plus.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-plus.dts
+index ee72fdac666..42841ee2d17 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-plus.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-plus.dts
+@@ -120,7 +120,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -128,7 +128,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-rev1.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-rev1.dts
+index 9301e345aea..05d00fde588 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-rev1.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b-rev1.dts
+@@ -121,7 +121,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -129,7 +129,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b.dts
+index b8459fd0f49..6ecbdf59654 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-b.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-b.dts
+@@ -121,7 +121,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -129,7 +129,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dts
+index fde85c8c7dc..7e099895159 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-cm.dts
+@@ -129,7 +129,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -137,7 +137,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts
+index f6d4e2c73df..68279b4fb22 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero-w.dts
+@@ -178,7 +178,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -186,7 +186,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero.dts b/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero.dts
+index 1721be8dbe2..8d3828b720f 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2708-rpi-zero.dts
+@@ -117,7 +117,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -125,7 +125,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2709-rpi-2-b.dts b/arch/arm/boot/dts/broadcom/bcm2709-rpi-2-b.dts
+index 7796e545da4..9acee1dc86a 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2709-rpi-2-b.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2709-rpi-2-b.dts
+@@ -120,7 +120,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -128,7 +128,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts b/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts
+index 36d00aa889a..ec4ae10998f 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2709-rpi-cm2.dts
+@@ -154,7 +154,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -162,7 +162,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-2-b.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-2-b.dts
+index ce48eb6073f..b16bf1dd507 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-2-b.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-2-b.dts
+@@ -120,7 +120,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -128,7 +128,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
+index 8973985e990..4a0f41c5b85 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b-plus.dts
+@@ -198,7 +198,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -206,7 +206,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
+index 35e6e990008..bd15e21d450 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-3-b.dts
+@@ -209,7 +209,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -217,7 +217,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm0.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm0.dts
+index b575de6b6ce..883b1a35d4c 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm0.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm0.dts
+@@ -173,7 +173,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -181,7 +181,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts
+index 0d6e9e61f87..e181e5b2838 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-cm3.dts
+@@ -154,7 +154,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -162,7 +162,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts b/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts
+index 16971e50229..0efac9f355f 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2710-rpi-zero-2-w.dts
+@@ -178,7 +178,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -186,7 +186,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+index a4aae12775d..19cef39ad9d 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-4-b.dts
+@@ -325,7 +325,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -333,7 +333,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+index c218f9cf823..6fc63d715e6 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4.dts
+@@ -299,7 +299,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -307,7 +307,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+index badf2a2fc3e..edeebf0894e 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
+@@ -182,7 +182,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -190,7 +190,7 @@ spidev0: spidev@0{
+ 	};
+ 
+ 	spidev1: spidev@1{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/rpi-rp2040-gpio-bridge.dtsi b/arch/arm/boot/dts/overlays/rpi-rp2040-gpio-bridge.dtsi
+index 2b7f670a1f6..a372eab148b 100644
+--- a/arch/arm/boot/dts/overlays/rpi-rp2040-gpio-bridge.dtsi
++++ b/arch/arm/boot/dts/overlays/rpi-rp2040-gpio-bridge.dtsi
+@@ -12,7 +12,7 @@ spi_bridge: spi@40 {
+ 	gpio-controller;
+ 
+ 	spi_bridgedev0: spidev@0{
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/seeed-can-fd-hat-v1-overlay.dts b/arch/arm/boot/dts/overlays/seeed-can-fd-hat-v1-overlay.dts
+index 210d027a073..b21fbef18e6 100644
+--- a/arch/arm/boot/dts/overlays/seeed-can-fd-hat-v1-overlay.dts
++++ b/arch/arm/boot/dts/overlays/seeed-can-fd-hat-v1-overlay.dts
+@@ -34,7 +34,7 @@ __overlay__ {
+ 			cs-gpios = <&gpio 18 1>;
+ 			status = "okay";
+ 			spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts
+index ea2794bc5fd..eb48073226b 100644
+--- a/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi1-1cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev1_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts
+index dab34ee79ae..149ca7ecc23 100644
+--- a/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi1-2cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev1_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -41,7 +41,7 @@ spidev1_0: spidev@0 {
+ 			};
+ 
+ 			spidev1_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts b/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts
+index bc7e7d04324..402924f31e2 100644
+--- a/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi1-3cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev1_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -41,7 +41,7 @@ spidev1_0: spidev@0 {
+ 			};
+ 
+ 			spidev1_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -50,7 +50,7 @@ spidev1_1: spidev@1 {
+ 			};
+ 
+ 			spidev1_2: spidev@2 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <2>;      /* CE2 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts
+index 2a29750462a..7eb73feeee3 100644
+--- a/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi2-1cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev2_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi2-1cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi2-1cs-pi5-overlay.dts
+index 44382cc5a7c..4033a187428 100644
+--- a/arch/arm/boot/dts/overlays/spi2-1cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi2-1cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev2_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts
+index 642678fc9dd..6e48e294e7a 100644
+--- a/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi2-2cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev2_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -41,7 +41,7 @@ spidev2_0: spidev@0 {
+ 			};
+ 
+ 			spidev2_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi2-2cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi2-2cs-pi5-overlay.dts
+index b37a2c21c7b..290e55c54f7 100644
+--- a/arch/arm/boot/dts/overlays/spi2-2cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi2-2cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev2_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -25,7 +25,7 @@ spidev2_0: spidev@0 {
+ 			};
+ 
+ 			spidev2_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts b/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts
+index 28d40c6c3c3..54d47eb58e8 100644
+--- a/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi2-3cs-overlay.dts
+@@ -32,7 +32,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev2_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -41,7 +41,7 @@ spidev2_0: spidev@0 {
+ 			};
+ 
+ 			spidev2_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -50,7 +50,7 @@ spidev2_1: spidev@1 {
+ 			};
+ 
+ 			spidev2_2: spidev@2 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <2>;      /* CE2 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
+index 7abea6d86fd..bbbdb1bdaa2 100644
+--- a/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi3-1cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev3_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi3-1cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi3-1cs-pi5-overlay.dts
+index a94e3a9f35c..c276b98900a 100644
+--- a/arch/arm/boot/dts/overlays/spi3-1cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi3-1cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev3_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
+index 2f474ac769f..58b0a513e89 100644
+--- a/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi3-2cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev3_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -33,7 +33,7 @@ spidev3_0: spidev@0 {
+ 			};
+ 
+ 			spidev3_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi3-2cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi3-2cs-pi5-overlay.dts
+index 259548b37d5..67fce310676 100644
+--- a/arch/arm/boot/dts/overlays/spi3-2cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi3-2cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev3_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -25,7 +25,7 @@ spidev3_0: spidev@0 {
+ 			};
+ 
+ 			spidev3_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
+index 66d89521124..5106db72253 100644
+--- a/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi4-1cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev4_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
+index 83d8cb8b918..30fac3dc1e7 100644
+--- a/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi4-2cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev4_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -33,7 +33,7 @@ spidev4_0: spidev@0 {
+ 			};
+ 
+ 			spidev4_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
+index 168b4825de3..f32a114907f 100644
+--- a/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi5-1cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev5_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi5-1cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi5-1cs-pi5-overlay.dts
+index bde1837f26c..d94516bded5 100644
+--- a/arch/arm/boot/dts/overlays/spi5-1cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi5-1cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev5_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
+index c2a239a34b3..58cf6e4d28c 100644
+--- a/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi5-2cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev5_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -33,7 +33,7 @@ spidev5_0: spidev@0 {
+ 			};
+ 
+ 			spidev5_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi5-2cs-pi5-overlay.dts b/arch/arm/boot/dts/overlays/spi5-2cs-pi5-overlay.dts
+index 2c9eee2a9db..683417caf24 100644
+--- a/arch/arm/boot/dts/overlays/spi5-2cs-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi5-2cs-pi5-overlay.dts
+@@ -16,7 +16,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev5_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -25,7 +25,7 @@ spidev5_0: spidev@0 {
+ 			};
+ 
+ 			spidev5_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts b/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
+index a784f8a17d2..2943fe23d6c 100644
+--- a/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi6-1cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev6_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts b/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
+index 8ef513814d2..8b340a07c24 100644
+--- a/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
++++ b/arch/arm/boot/dts/overlays/spi6-2cs-overlay.dts
+@@ -24,7 +24,7 @@ frag1: __overlay__ {
+ 			status = "okay";
+ 
+ 			spidev6_0: spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;      /* CE0 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+@@ -33,7 +33,7 @@ spidev6_0: spidev@0 {
+ 			};
+ 
+ 			spidev6_1: spidev@1 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <1>;      /* CE1 */
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm/boot/dts/overlays/waveshare-can-fd-hat-mode-a-overlay.dts b/arch/arm/boot/dts/overlays/waveshare-can-fd-hat-mode-a-overlay.dts
+index 59388cc3b0b..da2958582a2 100644
+--- a/arch/arm/boot/dts/overlays/waveshare-can-fd-hat-mode-a-overlay.dts
++++ b/arch/arm/boot/dts/overlays/waveshare-can-fd-hat-mode-a-overlay.dts
+@@ -36,7 +36,7 @@ __overlay__ {
+ 			cs-gpios = <&gpio 26 1>;
+ 			status = "okay";
+ 			spidev@0 {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				reg = <0>;
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+index 2939214f23a..72e9e57a172 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+@@ -459,7 +459,7 @@ &spi10 {
+ 	pinctrl-0 = <&spi10_pins &spi10_cs_pins>;
+ 
+ 	spidev10: spidev@0 {
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index 4eb7818f902..e122e666649 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -442,7 +442,7 @@ &spi10 {
+ 	pinctrl-0 = <&spi10_pins &spi10_cs_pins>;
+ 
+ 	spidev10: spidev@0 {
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+index f9d574c266f..5c151d73f61 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+@@ -443,7 +443,7 @@ &spi0 {
+ 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
+ 
+ 	spidev0: spidev@0 {
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <0>;	/* CE0 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+@@ -451,7 +451,7 @@ spidev0: spidev@0 {
+ 	};
+ 
+ 	spidev1: spidev@1 {
+-		compatible = "spidev";
++		compatible = "rohm,dh2228fv";
+ 		reg = <1>;	/* CE1 */
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+diff --git a/arch/arm64/boot/dts/broadcom/rp1.dtsi b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+index b746de80010..5e3eaac9f5a 100644
+--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
++++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+@@ -253,7 +253,7 @@ rp1_spi4: spi@60000 {
+ 			status = "disabled";
+ 
+ 			slave {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				spi-max-frequency = <1000000>;
+ 			};
+ 		};
+@@ -305,7 +305,7 @@ rp1_spi7: spi@6c000 {
+ 			status = "disabled";
+ 
+ 			slave {
+-				compatible = "spidev";
++				compatible = "rohm,dh2228fv";
+ 				spi-max-frequency = <1000000>;
+ 			};
+ 		};
+-- 
+2.43.0
+

--- a/artifacts/dtb/raspberrypi/patches/0002-0001-Revert-bcm2711-rpi-ds-Switch-to-dma40-channel-for-hd.patch
+++ b/artifacts/dtb/raspberrypi/patches/0002-0001-Revert-bcm2711-rpi-ds-Switch-to-dma40-channel-for-hd.patch
@@ -1,0 +1,46 @@
+From b9239483e122a6236fa75841f727bc1ad7a6240f Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Mon, 11 Dec 2023 09:54:46 +0100
+Subject: [PATCH] Revert "bcm2711-rpi-ds: Switch to dma40 channel for hdmi
+ audio"
+
+They are vendor changes in bcm2835-dma driver around new RPi5
+which  makes new device trees unusable without corresponding
+changes in DMA driver.
+
+Fixes [1] [RPi4] kernel: vc4_hdmi fef00700.hdmi: Could not...
+
+[1] https://bugzilla.suse.com/show_bug.cgi?id=1217512
+
+This reverts commit 0491a0aecb999b1a013ad4a6ad3816c535ac6e73.
+
+Signed-off-by: Ivan T. Ivanov <iivanov@suse.de>
+---
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+index 968db6362989..147a56fdbb68 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+@@ -374,7 +374,7 @@ &hdmi0 {
+ 		 <&firmware_clocks 14>,
+ 		 <&dvp 0>,
+ 		 <&clk_27MHz>;
+-	dmas = <&dma40 (10|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
++	dmas = <&dma (10|(1<<27)|(1<<24)|(10<<16)|(15<<20))>;
+ 	status = "disabled";
+ };
+ 
+@@ -407,7 +407,7 @@ &hdmi1 {
+ 		 <&firmware_clocks 14>,
+ 		 <&dvp 1>,
+ 		 <&clk_27MHz>;
+-	dmas = <&dma40 (17|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
++	dmas = <&dma (17|(1<<27)|(1<<24)|(10<<16)|(15<<20))>;
+ 	status = "disabled";
+ };
+ 
+-- 
+2.35.3
+

--- a/artifacts/dtb/raspberrypi/patches/0003-0002-ARM-dts-bcm2711-Fix-xHCI-power-domain.patch
+++ b/artifacts/dtb/raspberrypi/patches/0003-0002-ARM-dts-bcm2711-Fix-xHCI-power-domain.patch
@@ -1,0 +1,47 @@
+From d0aed470f09dda04825f5ac0c287cd6bbed1f10f Mon Sep 17 00:00:00 2001
+From: Andrea della Porta <andrea.porta@suse.com>
+Date: Tue, 15 Apr 2025 17:40:34 +0300
+Subject: [PATCH 3/3] ARM: dts: bcm2711: Fix xHCI power-domain
+
+During s2idle tests on the Raspberry CM4 the VPU firmware always crashes
+on xHCI power-domain resume:
+
+root@raspberrypi:/sys/power# echo freeze > state
+[   70.724347] xhci_suspend finished
+[   70.727730] xhci_plat_suspend finished
+[   70.755624] bcm2835-power bcm2835-power: Power grafx off
+[   70.761127]  USB: Set power to 0
+
+[   74.653040]  USB: Failed to set power to 1 (-110)
+
+This seems to be caused because of the mixed usage of
+raspberrypi-power and bcm2835-power at the same time. So avoid
+the usage of the VPU firmware power-domain driver, which
+prevents the VPU crash.
+
+Fixes: 522c35e08b53 ("ARM: dts: bcm2711: Add BCM2711 xHCI support")
+Link: https://github.com/raspberrypi/linux/issues/6537
+Signed-off-by: Stefan Wahren <wahrenst@gmx.net>
+Link: https://lore.kernel.org/r/20250201112729.31509-1-wahrenst@gmx.net
+Signed-off-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Signed-off-by: Andrea della Porta <andrea.porta@suse.com>
+---
+ arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+index 8326e3e0110..8d7ef09923d 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+@@ -145,7 +145,7 @@ xhci: xhci@7e9c0000 {
+ 		status = "disabled";
+ 		reg = <0x0 0x7e9c0000  0x0 0x100000>;
+ 		interrupts = <GIC_SPI 176 IRQ_TYPE_LEVEL_HIGH>;
+-		power-domains = <&power RPI_POWER_DOMAIN_USB>;
++		power-domains = <&pm BCM2835_POWER_DOMAIN_USB>;
+ 	};
+ };
+ 
+-- 
+2.43.0
+

--- a/artifacts/dtb/raspberrypi/patches/0004-0001-dts-rp1-Wrap-RP1-node-into-nexus-node-as-expected-by.patch
+++ b/artifacts/dtb/raspberrypi/patches/0004-0001-dts-rp1-Wrap-RP1-node-into-nexus-node-as-expected-by.patch
@@ -1,0 +1,562 @@
+From 5084e13d34501811ac5927725dc5a1950cfb61d6 Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Thu, 15 May 2025 13:52:48 +0300
+Subject: [PATCH] dts: rp1: Wrap RP1 node into nexus node as expected by
+ upstream
+
+---
+ .../boot/dts/broadcom/bcm2712-rpi-5-b.dts     |   6 +-
+ .../boot/dts/broadcom/bcm2712-rpi-cm5.dtsi    |   6 +-
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi |   2 +-
+ arch/arm64/boot/dts/broadcom/rp1.dtsi         | 140 +++++++++---------
+ 4 files changed, 81 insertions(+), 73 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+index 72e9e57a172..62ac3691248 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+@@ -138,9 +138,9 @@ &rp1 {
+ 
+ 	// outbound access aimed at PCIe 0_00xxxxxx -> RP1 c0_40xxxxxx
+ 	// This is the RP1 peripheral space
+-	ranges = <0xc0 0x40000000
+-		  0x02000000 0x00 0x00000000
+-		  0x00 0x00410000>;
++	ranges = <0x00 0x40000000
++		  0x01 0x00 0x00000000
++		  0x00 0x00400000>;
+ 
+ 	dma-ranges =
+ 	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index e122e666649..5f57fa5daa7 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -125,9 +125,9 @@ &rp1 {
+ 
+ 	// outbound access aimed at PCIe 0_00xxxxxx -> RP1 c0_40xxxxxx
+ 	// This is the RP1 peripheral space
+-	ranges = <0xc0 0x40000000
+-		  0x02000000 0x00 0x00000000
+-		  0x00 0x00410000>;
++	ranges = <0x00 0x40000000
++		  0x01 0x00 0x00000000
++		  0x00 0x00400000>;
+ 
+ 	dma-ranges =
+ 	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+index 5c151d73f61..4a1a59388d8 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+@@ -321,7 +321,7 @@ &rp1 {
+ 	gpiomem@d0000 {
+ 		/* Export IO_BANKs, RIO_BANKs and PADS_BANKs to userspace */
+ 		compatible = "raspberrypi,gpiomem";
+-		reg = <0xc0 0x400d0000  0x0 0x30000>;
++		reg = <0x00 0x400d0000  0x0 0x30000>;
+ 		chardev-name = "gpiomem0";
+ 	};
+ };
+diff --git a/arch/arm64/boot/dts/broadcom/rp1.dtsi b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+index 5e3eaac9f5a..a401aae1097 100644
+--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
++++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+@@ -3,20 +3,27 @@
+ #include <dt-bindings/mfd/rp1.h>
+ 
+ &rp1_target {
++    rp1_nexus {
++	compatible = "pci1de4,1";
++	#address-cells = <3>;
++	#size-cells = <2>;
++	ranges = <0x01 0x00 0x00000000
++		  0x02000000 0x00 0x00000000
++		  0x0 0x400000>;
++	interrupt-controller;
++	#interrupt-cells = <2>;
++
+ 	rp1: rp1 {
+ 		compatible = "simple-bus";
+ 		#address-cells = <2>;
+ 		#size-cells = <2>;
+-		#interrupt-cells = <2>;
+-		interrupt-controller;
+-		interrupt-parent = <&rp1>;
+ 
+ 		// ranges and dma-ranges must be provided by the includer
+ 
+ 		rp1_mbox: mailbox@8000 {
+ 			compatible = "raspberrypi,rp1-mbox";
+ 			status = "disabled";
+-			reg = <0xc0 0x40008000  0x0 0x4000>;  // SYSCFG
++			reg = <0x00 0x40008000  0x0 0x4000>;  // SYSCFG
+ 			interrupts = <RP1_INT_SYSCFG IRQ_TYPE_LEVEL_HIGH>;
+ 			#mbox-cells = <1>;
+ 		};
+@@ -24,7 +31,7 @@ rp1_mbox: mailbox@8000 {
+ 		rp1_clocks: clocks@18000 {
+ 			compatible = "raspberrypi,rp1-clocks";
+ 			#clock-cells = <1>;
+-			reg = <0xc0 0x40018000 0x0 0x10038>;
++			reg = <0x00 0x40018000 0x0 0x10038>;
+ 			clocks = <&clk_xosc>;
+ 
+ 			assigned-clocks = <&rp1_clocks RP1_PLL_SYS_CORE>,
+@@ -61,7 +68,7 @@ rp1_clocks: clocks@18000 {
+ 
+ 		rp1_uart0: serial@30000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x40030000  0x0 0x100>;
++			reg = <0x00 0x40030000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -78,7 +85,7 @@ rp1_uart0: serial@30000 {
+ 
+ 		rp1_uart1: serial@34000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x40034000  0x0 0x100>;
++			reg = <0x00 0x40034000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART1 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -95,7 +102,7 @@ rp1_uart1: serial@34000 {
+ 
+ 		rp1_uart2: serial@38000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x40038000  0x0 0x100>;
++			reg = <0x00 0x40038000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART2 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -112,7 +119,7 @@ rp1_uart2: serial@38000 {
+ 
+ 		rp1_uart3: serial@3c000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x4003c000  0x0 0x100>;
++			reg = <0x00 0x4003c000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART3 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -129,7 +136,7 @@ rp1_uart3: serial@3c000 {
+ 
+ 		rp1_uart4: serial@40000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x40040000  0x0 0x100>;
++			reg = <0x00 0x40040000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART4 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -146,7 +153,7 @@ rp1_uart4: serial@40000 {
+ 
+ 		rp1_uart5: serial@44000 {
+ 			compatible = "arm,pl011-axi";
+-			reg = <0xc0 0x40044000  0x0 0x100>;
++			reg = <0x00 0x40044000  0x0 0x100>;
+ 			interrupts = <RP1_INT_UART5 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+@@ -162,7 +169,7 @@ rp1_uart5: serial@44000 {
+ 		};
+ 
+ 		rp1_spi8: spi@4c000 {
+-			reg = <0xc0 0x4004c000  0x0 0x130>;
++			reg = <0x00 0x4004c000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI8 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -177,7 +184,7 @@ rp1_spi8: spi@4c000 {
+ 		};
+ 
+ 		rp1_spi0: spi@50000 {
+-			reg = <0xc0 0x40050000  0x0 0x130>;
++			reg = <0x00 0x40050000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI0 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -192,7 +199,7 @@ rp1_spi0: spi@50000 {
+ 		};
+ 
+ 		rp1_spi1: spi@54000 {
+-			reg = <0xc0 0x40054000  0x0 0x130>;
++			reg = <0x00 0x40054000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI1 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -207,7 +214,7 @@ rp1_spi1: spi@54000 {
+ 		};
+ 
+ 		rp1_spi2: spi@58000 {
+-			reg = <0xc0 0x40058000  0x0 0x130>;
++			reg = <0x00 0x40058000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI2 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -222,7 +229,7 @@ rp1_spi2: spi@58000 {
+ 		};
+ 
+ 		rp1_spi3: spi@5c000 {
+-			reg = <0xc0 0x4005c000  0x0 0x130>;
++			reg = <0x00 0x4005c000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI3 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -238,7 +245,7 @@ rp1_spi3: spi@5c000 {
+ 
+ 		// SPI4 is a target/slave interface
+ 		rp1_spi4: spi@60000 {
+-			reg = <0xc0 0x40060000  0x0 0x130>;
++			reg = <0x00 0x40060000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI4 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -259,7 +266,7 @@ slave {
+ 		};
+ 
+ 		rp1_spi5: spi@64000 {
+-			reg = <0xc0 0x40064000  0x0 0x130>;
++			reg = <0x00 0x40064000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI5 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -274,7 +281,7 @@ rp1_spi5: spi@64000 {
+ 		};
+ 
+ 		rp1_spi6: spi@68000 {
+-			reg = <0xc0 0x40068000  0x0 0x130>;
++			reg = <0x00 0x40068000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI6 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -290,7 +297,7 @@ rp1_spi6: spi@68000 {
+ 
+ 		// SPI7 is a target/slave interface
+ 		rp1_spi7: spi@6c000 {
+-			reg = <0xc0 0x4006c000  0x0 0x130>;
++			reg = <0x00 0x4006c000  0x0 0x130>;
+ 			compatible = "snps,dw-apb-ssi";
+ 			interrupts = <RP1_INT_SPI7 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -311,7 +318,7 @@ slave {
+ 		};
+ 
+ 		rp1_i2c0: i2c@70000 {
+-			reg = <0xc0 0x40070000  0x0 0x1000>;
++			reg = <0x00 0x40070000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C0 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -321,7 +328,7 @@ rp1_i2c0: i2c@70000 {
+ 		};
+ 
+ 		rp1_i2c1: i2c@74000 {
+-			reg = <0xc0 0x40074000  0x0 0x1000>;
++			reg = <0x00 0x40074000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C1 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -331,7 +338,7 @@ rp1_i2c1: i2c@74000 {
+ 		};
+ 
+ 		rp1_i2c2: i2c@78000 {
+-			reg = <0xc0 0x40078000  0x0 0x1000>;
++			reg = <0x00 0x40078000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C2 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -341,7 +348,7 @@ rp1_i2c2: i2c@78000 {
+ 		};
+ 
+ 		rp1_i2c3: i2c@7c000 {
+-			reg = <0xc0 0x4007c000  0x0 0x1000>;
++			reg = <0x00 0x4007c000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C3 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -351,7 +358,7 @@ rp1_i2c3: i2c@7c000 {
+ 		};
+ 
+ 		rp1_i2c4: i2c@80000 {
+-			reg = <0xc0 0x40080000  0x0 0x1000>;
++			reg = <0x00 0x40080000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C4 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -361,7 +368,7 @@ rp1_i2c4: i2c@80000 {
+ 		};
+ 
+ 		rp1_i2c5: i2c@84000 {
+-			reg = <0xc0 0x40084000  0x0 0x1000>;
++			reg = <0x00 0x40084000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C5 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -371,7 +378,7 @@ rp1_i2c5: i2c@84000 {
+ 		};
+ 
+ 		rp1_i2c6: i2c@88000 {
+-			reg = <0xc0 0x40088000  0x0 0x1000>;
++			reg = <0x00 0x40088000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2c";
+ 			interrupts = <RP1_INT_I2C6 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS>;
+@@ -382,7 +389,7 @@ rp1_i2c6: i2c@88000 {
+ 
+ 		rp1_audio_out: audio_out@94000 {
+ 			compatible = "raspberrypi,rp1-audio-out";
+-			reg = <0xc0 0x40094000 0x0 0x4000>;
++			reg = <0x00 0x40094000 0x0 0x4000>;
+ 			clocks = <&rp1_clocks RP1_CLK_AUDIO_OUT>;
+ 			assigned-clocks = <&rp1_clocks RP1_CLK_AUDIO_OUT>;
+ 			assigned-clock-rates = <153600000>;
+@@ -396,7 +403,7 @@ rp1_audio_out: audio_out@94000 {
+ 
+ 		rp1_pwm0: pwm@98000 {
+ 			compatible = "raspberrypi,rp1-pwm";
+-			reg = <0xc0 0x40098000  0x0 0x100>;
++			reg = <0x00 0x40098000  0x0 0x100>;
+ 			#pwm-cells = <3>;
+ 			clocks = <&rp1_clocks RP1_CLK_PWM0>;
+ 			assigned-clocks = <&rp1_clocks RP1_CLK_PWM0>;
+@@ -406,7 +413,7 @@ rp1_pwm0: pwm@98000 {
+ 
+ 		rp1_pwm1: pwm@9c000 {
+ 			compatible = "raspberrypi,rp1-pwm";
+-			reg = <0xc0 0x4009c000  0x0 0x100>;
++			reg = <0x00 0x4009c000  0x0 0x100>;
+ 			#pwm-cells = <3>;
+ 			clocks = <&rp1_clocks RP1_CLK_PWM1>;
+ 			assigned-clocks = <&rp1_clocks RP1_CLK_PWM1>;
+@@ -415,7 +422,7 @@ rp1_pwm1: pwm@9c000 {
+ 		};
+ 
+ 		rp1_i2s0: i2s@a0000 {
+-			reg = <0xc0 0x400a0000  0x0 0x1000>;
++			reg = <0x00 0x400a0000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2s";
+ 			// Providing an interrupt disables DMA
+ 			// interrupts = <RP1_INT_I2S0 IRQ_TYPE_LEVEL_HIGH>;
+@@ -429,7 +436,7 @@ rp1_i2s0: i2s@a0000 {
+ 		};
+ 
+ 		rp1_i2s1: i2s@a4000 {
+-			reg = <0xc0 0x400a4000  0x0 0x1000>;
++			reg = <0x00 0x400a4000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2s";
+ 			// Providing an interrupt disables DMA
+ 			// interrupts = <RP1_INT_I2S1 IRQ_TYPE_LEVEL_HIGH>;
+@@ -443,7 +450,7 @@ rp1_i2s1: i2s@a4000 {
+ 		};
+ 
+ 		rp1_i2s2: i2s@a8000 {
+-			reg = <0xc0 0x400a8000  0x0 0x1000>;
++			reg = <0x00 0x400a8000  0x0 0x1000>;
+ 			compatible = "snps,designware-i2s";
+ 			// Providing an interrupt disables DMA
+ 			// interrupts = <RP1_INT_I2S2 IRQ_TYPE_LEVEL_HIGH>;
+@@ -453,7 +460,7 @@ rp1_i2s2: i2s@a8000 {
+ 
+ 		rp1_sdio_clk0: sdio_clk0@b0004 {
+ 			compatible = "raspberrypi,rp1-sdio-clk";
+-			reg = <0xc0 0x400b0004 0x0 0x1c>;
++			reg = <0x00 0x400b0004 0x0 0x1c>;
+ 			clocks = <&sdio_src &sdhci_core>;
+ 			clock-names = "src", "base";
+ 			#clock-cells = <0>;
+@@ -462,7 +469,7 @@ rp1_sdio_clk0: sdio_clk0@b0004 {
+ 
+ 		rp1_sdio_clk1: sdio_clk1@b4004 {
+ 			compatible = "raspberrypi,rp1-sdio-clk";
+-			reg = <0xc0 0x400b4004 0x0 0x1c>;
++			reg = <0x00 0x400b4004 0x0 0x1c>;
+ 			clocks = <&sdio_src &sdhci_core>;
+ 			clock-names = "src", "base";
+ 			#clock-cells = <0>;
+@@ -471,7 +478,7 @@ rp1_sdio_clk1: sdio_clk1@b4004 {
+ 
+ 		rp1_adc: adc@c8000 {
+ 			compatible = "raspberrypi,rp1-adc";
+-			reg = <0xc0 0x400c8000 0x0 0x4000>;
++			reg = <0x00 0x400c8000 0x0 0x4000>;
+ 			clocks = <&rp1_clocks RP1_CLK_ADC>;
+ 			clock-names = "adcclk";
+ 			#clock-cells = <0>;
+@@ -480,9 +487,9 @@ rp1_adc: adc@c8000 {
+ 		};
+ 
+ 		rp1_gpio: gpio@d0000 {
+-			reg = <0xc0 0x400d0000  0x0 0xc000>,
+-			      <0xc0 0x400e0000  0x0 0xc000>,
+-			      <0xc0 0x400f0000  0x0 0xc000>;
++			reg = <0x00 0x400d0000  0x0 0xc000>,
++			      <0x00 0x400e0000  0x0 0xc000>,
++			      <0x00 0x400f0000  0x0 0xc000>;
+ 			compatible = "raspberrypi,rp1-gpio";
+ 			interrupts = <RP1_INT_IO_BANK0 IRQ_TYPE_LEVEL_HIGH>,
+ 				     <RP1_INT_IO_BANK1 IRQ_TYPE_LEVEL_HIGH>,
+@@ -997,7 +1004,7 @@ rp1_audio_out_12_13: rp1_audio_out_12_13 {
+ 		};
+ 
+ 		rp1_eth: ethernet@100000 {
+-			reg = <0xc0 0x40100000  0x0 0x4000>;
++			reg = <0x00 0x40100000  0x0 0x4000>;
+ 			compatible = "raspberrypi,rp1-gem", "cdns,macb";
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+@@ -1017,10 +1024,10 @@ &rp1_clocks RP1_CLK_ETH_TSU
+ 
+ 		rp1_csi0: csi@110000 {
+ 			compatible = "raspberrypi,rp1-cfe";
+-			reg = <0xc0 0x40110000  0x0 0x100>, // CSI2 DMA address
+-			      <0xc0 0x40114000  0x0 0x100>, // PHY/CSI Host address
+-			      <0xc0 0x40120000  0x0 0x100>, // MIPI CFG address
+-			      <0xc0 0x40124000  0x0 0x1000>; // PiSP FE address
++			reg = <0x00 0x40110000  0x0 0x100>, // CSI2 DMA address
++			      <0x00 0x40114000  0x0 0x100>, // PHY/CSI Host address
++			      <0x00 0x40120000  0x0 0x100>, // MIPI CFG address
++			      <0x00 0x40124000  0x0 0x1000>; // PiSP FE address
+ 
+ 			// interrupts must match rp1_pisp_fe setup
+ 			interrupts = <RP1_INT_MIPI0 IRQ_TYPE_LEVEL_HIGH>;
+@@ -1036,10 +1043,10 @@ rp1_csi0: csi@110000 {
+ 
+ 		rp1_csi1: csi@128000 {
+ 			compatible = "raspberrypi,rp1-cfe";
+-			reg = <0xc0 0x40128000  0x0 0x100>, // CSI2 DMA address
+-			      <0xc0 0x4012c000  0x0 0x100>, // PHY/CSI Host address
+-			      <0xc0 0x40138000  0x0 0x100>, // MIPI CFG address
+-			      <0xc0 0x4013c000  0x0 0x1000>; // PiSP FE address
++			reg = <0x00 0x40128000  0x0 0x100>, // CSI2 DMA address
++			      <0x00 0x4012c000  0x0 0x100>, // PHY/CSI Host address
++			      <0x00 0x40138000  0x0 0x100>, // MIPI CFG address
++			      <0x00 0x4013c000  0x0 0x1000>; // PiSP FE address
+ 
+ 			// interrupts must match rp1_pisp_fe setup
+ 			interrupts = <RP1_INT_MIPI1 IRQ_TYPE_LEVEL_HIGH>;
+@@ -1054,7 +1061,7 @@ rp1_csi1: csi@128000 {
+ 		};
+ 
+ 		rp1_pio: pio@178000 {
+-			reg = <0xc0 0x40178000  0x0 0x20>;
++			reg = <0x00 0x40178000  0x0 0x20>;
+ 			compatible = "raspberrypi,rp1-pio";
+ 			firmware = <&rp1_firmware>;
+ 			dmas = <&rp1_dma RP1_DMA_PIO_CH0_TX>, <&rp1_dma RP1_DMA_PIO_CH0_RX>,
+@@ -1066,7 +1073,7 @@ rp1_pio: pio@178000 {
+ 		};
+ 
+ 		rp1_mmc0: mmc@180000 {
+-			reg = <0xc0 0x40180000  0x0 0x100>;
++			reg = <0x00 0x40180000  0x0 0x100>;
+ 			compatible = "raspberrypi,rp1-dwcmshc";
+ 			interrupts = <RP1_INT_SDIO0 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS &sdhci_core
+@@ -1082,7 +1089,7 @@ &rp1_clocks RP1_CLK_SDIO_TIMER
+ 		};
+ 
+ 		rp1_mmc1: mmc@184000 {
+-			reg = <0xc0 0x40184000  0x0 0x100>;
++			reg = <0x00 0x40184000  0x0 0x100>;
+ 			compatible = "raspberrypi,rp1-dwcmshc";
+ 			interrupts = <RP1_INT_SDIO1 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_SYS &sdhci_core
+@@ -1098,7 +1105,7 @@ &rp1_clocks RP1_CLK_SDIO_TIMER
+ 		};
+ 
+ 		rp1_dma: dma@188000 {
+-			reg = <0xc0 0x40188000  0x0 0x1000>;
++			reg = <0x00 0x40188000  0x0 0x1000>;
+ 			compatible = "snps,axi-dma-1.01a";
+ 			interrupts = <RP1_INT_DMA IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_DMA &rp1_clocks RP1_CLK_SYS>;
+@@ -1116,7 +1123,7 @@ rp1_dma: dma@188000 {
+ 		};
+ 
+ 		rp1_usb0: usb@200000 {
+-			reg = <0xc0 0x40200000  0x0 0x100000>;
++			reg = <0x00 0x40200000  0x0 0x100000>;
+ 			compatible = "snps,dwc3";
+ 			dr_mode = "host";
+ 			usb3-lpm-capable;
+@@ -1133,7 +1140,7 @@ rp1_usb0: usb@200000 {
+ 		};
+ 
+ 		rp1_usb1: usb@300000 {
+-			reg = <0xc0 0x40300000  0x0 0x100000>;
++			reg = <0x00 0x40300000  0x0 0x100000>;
+ 			compatible = "snps,dwc3";
+ 			dr_mode = "host";
+ 			usb3-lpm-capable;
+@@ -1152,9 +1159,9 @@ rp1_usb1: usb@300000 {
+ 		rp1_dsi0: dsi@110000 {
+ 			compatible = "raspberrypi,rp1dsi";
+ 			status = "disabled";
+-			reg = <0xc0 0x40118000  0x0 0x1000>,  // MIPI0 DSI DMA (ArgonDPI)
+-			      <0xc0 0x4011c000  0x0 0x1000>,  // MIPI0 DSI Host (SNPS)
+-			      <0xc0 0x40120000  0x0 0x1000>;  // MIPI0 CFG
++			reg = <0x00 0x40118000  0x0 0x1000>,  // MIPI0 DSI DMA (ArgonDPI)
++			      <0x00 0x4011c000  0x0 0x1000>,  // MIPI0 DSI Host (SNPS)
++			      <0x00 0x40120000  0x0 0x1000>;  // MIPI0 CFG
+ 
+ 			interrupts = <RP1_INT_MIPI0 IRQ_TYPE_LEVEL_HIGH>;
+ 
+@@ -1172,9 +1179,9 @@ rp1_dsi0: dsi@110000 {
+ 		rp1_dsi1: dsi@128000 {
+ 			compatible = "raspberrypi,rp1dsi";
+ 			status = "disabled";
+-			reg = <0xc0 0x40130000  0x0 0x1000>,  // MIPI1 DSI DMA (ArgonDPI)
+-		              <0xc0 0x40134000  0x0 0x1000>,  // MIPI1 DSI Host (SNPS)
+-		              <0xc0 0x40138000  0x0 0x1000>;  // MIPI1 CFG
++			reg = <0x00 0x40130000  0x0 0x1000>,  // MIPI1 DSI DMA (ArgonDPI)
++		              <0x00 0x40134000  0x0 0x1000>,  // MIPI1 DSI Host (SNPS)
++		              <0x00 0x40138000  0x0 0x1000>;  // MIPI1 CFG
+ 
+ 			interrupts = <RP1_INT_MIPI1 IRQ_TYPE_LEVEL_HIGH>;
+ 
+@@ -1194,8 +1201,8 @@ rp1_dsi1: dsi@128000 {
+ 		rp1_vec: vec@144000 {
+ 			compatible = "raspberrypi,rp1vec";
+ 			status = "disabled";
+-			reg = <0xc0 0x40144000  0x0 0x1000>, // VIDEO_OUT_VEC
+-			      <0xc0 0x40140000  0x0 0x1000>; // VIDEO_OUT_CFG
++			reg = <0x00 0x40144000  0x0 0x1000>, // VIDEO_OUT_VEC
++			      <0x00 0x40140000  0x0 0x1000>; // VIDEO_OUT_CFG
+ 
+ 			interrupts = <RP1_INT_VIDEO_OUT IRQ_TYPE_LEVEL_HIGH>;
+ 
+@@ -1215,8 +1222,8 @@ rp1_vec: vec@144000 {
+ 		rp1_dpi: dpi@148000 {
+ 			compatible = "raspberrypi,rp1dpi";
+ 			status = "disabled";
+-			reg = <0xc0 0x40148000  0x0 0x1000>, // VIDEO_OUT DPI
+-			      <0xc0 0x40140000  0x0 0x1000>; // VIDEO_OUT_CFG
++			reg = <0x00 0x40148000  0x0 0x1000>, // VIDEO_OUT DPI
++			      <0x00 0x40140000  0x0 0x1000>; // VIDEO_OUT_CFG
+ 
+ 			interrupts = <RP1_INT_VIDEO_OUT IRQ_TYPE_LEVEL_HIGH>;
+ 
+@@ -1231,10 +1238,10 @@ rp1_dpi: dpi@148000 {
+ 
+ 		sram: sram@400000 {
+ 			compatible = "mmio-sram";
+-			reg = <0xc0 0x40400000  0x0 0x10000>;
++			reg = <0x00 0x40400000  0x0 0x10000>;
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+-			ranges = <0  0xc0 0x40400000  0x10000>;
++			ranges = <0  0x00 0x40400000  0x10000>;
+ 
+ 			rp1_fw_shmem: shmem@ff00 {
+ 				compatible = "raspberrypi,rp1-shmem";
+@@ -1242,6 +1249,7 @@ rp1_fw_shmem: shmem@ff00 {
+ 			};
+ 		};
+ 	};
++    };
+ };
+ 
+ &clocks {
+-- 
+2.43.0
+

--- a/artifacts/dtb/raspberrypi/patches/0005-0001-ARM-dts-bcm2712-Remove-DMA-support.patch
+++ b/artifacts/dtb/raspberrypi/patches/0005-0001-ARM-dts-bcm2712-Remove-DMA-support.patch
@@ -1,0 +1,107 @@
+From e2d0f0265cd28d397f86848dc860e45107e08ead Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Wed, 18 Jun 2025 10:47:43 +0300
+Subject: [PATCH] ARM: dts: bcm2712: Remove DMA support
+
+No upstream "brcm,bcm2712-dma" DMA driver support.
+Drivers using these DMA channels will work even without them.
+---
+ .../arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi |  4 ----
+ .../boot/dts/overlays/bcm2712d0-overlay.dts   | 21 -------------------
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi | 15 -------------
+ .../boot/dts/broadcom/bcm2712d0-rpi-5-b.dts   | 11 ----------
+ 4 files changed, 51 deletions(-)
+
+diff --git a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+index fcf70190737..0c4c90a292a 100644
+--- a/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm2711-rpi-ds.dtsi
+@@ -17,10 +17,6 @@ __overrides__ {
+ 		sd = <&emmc2>,"status";
+ 
+ 		sd_poll_once = <&emmc2>, "non-removable?";
+-		spi_dma4 = <&spi0>, "dmas:0=", <&dma40>,
+-			   <&spi0>, "dmas:8=", <&dma40>;
+-		i2s_dma4 = <&i2s>, "dmas:0=", <&dma40>,
+-			   <&i2s>, "dmas:8=", <&dma40>;
+ 	};
+ 
+ 	scb: scb {
+diff --git a/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts b/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts
+index 1ee74234e80..d7a4131f5ff 100644
+--- a/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts
++++ b/arch/arm/boot/dts/overlays/bcm2712d0-overlay.dts
+@@ -44,25 +44,4 @@ __overlay__ {
+ 			interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
+ 		};
+ 	};
+-
+-	fragment@5 {
+-		target = <&spi10>;
+-		__overlay__ {
+-			dmas = <&dma40 3>, <&dma40 4>;
+-		};
+-	};
+-
+-	fragment@6 {
+-		target = <&hdmi0>;
+-		__overlay__ {
+-			dmas = <&dma40 (12|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-		};
+-	};
+-
+-	fragment@7 {
+-		target = <&hdmi1>;
+-		__overlay__ {
+-			dmas = <&dma40 (13|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-		};
+-	};
+ };
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+index 4a1a59388d8..a07288f88b3 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi.dtsi
+@@ -249,21 +249,6 @@ &dma40 {
+ 	brcm,dma-channel-mask = <0x07c0>;
+ };
+ 
+-&hdmi0 {
+-	dmas = <&dma40 (10|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-	dma-names = "audio-rx";
+-};
+-
+-&hdmi1 {
+-	dmas = <&dma40 (17|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-	dma-names = "audio-rx";
+-};
+-
+-&spi10 {
+-	dmas = <&dma40 6>, <&dma40 7>;
+-	dma-names = "tx", "rx";
+-};
+-
+ &usb {
+ 	power-domains = <&power RPI_POWER_DOMAIN_USB>;
+ };
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts
+index d06536bc759..dbcbce07593 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712d0-rpi-5-b.dts
+@@ -94,14 +94,3 @@ &uart10 {
+ 	interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
+ };
+ 
+-&spi10 {
+-	dmas = <&dma40 3>, <&dma40 4>;
+-};
+-
+-&hdmi0 {
+-	dmas = <&dma40 (12|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-};
+-
+-&hdmi1 {
+-	dmas = <&dma40 (13|(1<<30)|(1<<24)|(10<<16)|(15<<20))>;
+-};
+-- 
+2.43.0
+

--- a/artifacts/dtb/raspberrypi/patches/0006-0001-ARM-dts-bcm2712-Slow-down-eMMC-interface.patch
+++ b/artifacts/dtb/raspberrypi/patches/0006-0001-ARM-dts-bcm2712-Slow-down-eMMC-interface.patch
@@ -1,0 +1,40 @@
+From b925461f55fcd1de4b30dae01786c2c703394cb4 Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Wed, 18 Jun 2025 15:58:17 +0300
+Subject: [PATCH] ARM: dts: bcm2712: Slow down eMMC interface
+
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi      | 1 -
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi | 3 ---
+ 2 files changed, 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+index 95482c40a9e..441eb51b73e 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+@@ -401,7 +401,6 @@ sdio2: mmc@1100000 {
+ 		clocks = <&clk_emmc2>;
+ 		sdhci-caps-mask = <0x0000C000 0x0>;
+ 		sdhci-caps = <0x0 0x0>;
+-		supports-cqe = <1>;
+ 		mmc-ddr-3_3v;
+ 		status = "disabled";
+ 	};
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index 5f57fa5daa7..c5c9abe9fda 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -294,10 +294,7 @@ &sdio1 {
+ 	sd-uhs-ddr50;
+ 	sd-uhs-sdr104;
+ 	mmc-hs200-1_8v;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ 	broken-cd;
+-	supports-cqe = <1>;
+ 	status = "okay";
+ };
+ 
+-- 
+2.43.0
+

--- a/artifacts/dtb/raspberrypi/patches/0007-bcm2712-fix-compatible.patch
+++ b/artifacts/dtb/raspberrypi/patches/0007-bcm2712-fix-compatible.patch
@@ -1,0 +1,29 @@
+Index: b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+===================================================================
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi
+@@ -143,7 +143,7 @@
+ 	};
+ 
+ 	pinctrl: pinctrl@7d504100 {
+-		compatible = "brcm,bcm2712-pinctrl";
++		compatible = "brcm,bcm2712c0-pinctrl";
+ 		reg = <0x7d504100 0x30>;
+ 
+ 		uarta_24_pins: uarta_24_pins {
+@@ -213,7 +213,7 @@
+ 	};
+ 
+ 	pinctrl_aon: pinctrl@7d510700 {
+-		compatible = "brcm,bcm2712-aon-pinctrl";
++		compatible = "brcm,bcm2712c0-aon-pinctrl";
+ 		reg = <0x7d510700 0x20>;
+ 
+ 		i2c3_m4_agpio0_pins: i2c3_m4_agpio0_pins {
+@@ -496,4 +496,4 @@
+ 
+ &pcie2 {
+ 	brcm,vdm-qos-map = /bits/ 8 <8 8 8 9 10 10 11 11>;
+-};
+\ No newline at end of file
++};

--- a/artifacts/dtb/raspberrypi/patches/0008-0001-Amend-the-RP1-ethernet-node-to-work-with-upstream-dr.patch
+++ b/artifacts/dtb/raspberrypi/patches/0008-0001-Amend-the-RP1-ethernet-node-to-work-with-upstream-dr.patch
@@ -1,0 +1,71 @@
+From 75095746b0b7e2b448d0a8847c9ec69fb7b8364e Mon Sep 17 00:00:00 2001
+From: Andrea della Porta <andrea.porta@suse.com>
+Date: Tue, 16 Sep 2025 10:59:21 +0300
+Subject: [PATCH] Amend the RP1 ethernet node to work with upstream driver
+
+---
+ .../boot/dts/broadcom/bcm2712-rpi-5-b.dts      | 14 ++++++++++----
+ .../boot/dts/broadcom/bcm2712-rpi-cm5.dtsi     | 18 ++++++++++++------
+ 2 files changed, 22 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+index 2939214..a2c3450 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+@@ -169,12 +169,18 @@ rp1_target: &pcie2 {
+ &rp1_eth {
+ 	status = "okay";
+ 	phy-handle = <&phy1>;
+-	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
+-	phy-reset-duration = <5>;
+ 
+-	phy1: ethernet-phy@1 {
++	mdio {
+ 		reg = <0x1>;
+-		brcm,powerdown-enable;
++		reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
++		reset-delay-us = <5000>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		phy1: ethernet-phy@1 {
++			reg = <0x1>;
++			brcm,powerdown-enable;
++		};
+ 	};
+ };
+ 
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index 4eb7818..18e8157 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -156,14 +156,20 @@ rp1_target: &pcie2 {
+ &rp1_eth {
+ 	status = "okay";
+ 	phy-handle = <&phy1>;
+-	phy-reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
+-	phy-reset-duration = <5>;
+ 
+-	phy1: ethernet-phy@1 {
++	mdio {
+ 		reg = <0x1>;
+-		brcm,powerdown-enable;
+-		interrupt-parent = <&gpio>;
+-		interrupts = <37 IRQ_TYPE_LEVEL_LOW>;
++		reset-gpios = <&rp1_gpio 32 GPIO_ACTIVE_LOW>;
++		reset-delay-us = <5000>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		phy1: ethernet-phy@1 {
++			reg = <0x1>;
++			brcm,powerdown-enable;
++			interrupt-parent = <&gpio>;
++			interrupts = <37 IRQ_TYPE_LEVEL_LOW>;
++		};
+ 	};
+ };
+ 
+-- 
+2.35.3
+

--- a/artifacts/dtb/raspberrypi/patches/0009-0001-dts-overlays-Adjust-them-for-RPi5.patch
+++ b/artifacts/dtb/raspberrypi/patches/0009-0001-dts-overlays-Adjust-them-for-RPi5.patch
@@ -1,0 +1,197 @@
+From b73602e0a32408605a9fe7b4dd29e0402b1fa8e3 Mon Sep 17 00:00:00 2001
+From: "Ivan T. Ivanov" <iivanov@suse.de>
+Date: Thu, 23 Oct 2025 03:30:36 +0300
+Subject: [PATCH] dts: overlays: Adjust them for RPi5
+
+- Add 64 bit size CMA overlay
+  Compared to older devices RPi5 uses #size-cells=<2>.
+  Create new overlay and add it to overlay_map so it
+  could automagicaly loaded by the firmware.
+
+- Add map for enabling Bluetooth on RPi5
+  Bluetooth on RPi5 do not need to be enabled, but
+  because we unconditionally enable-bt for all
+  devices create similar overlay for RPi5 and
+  add it to overlay_map.
+
+- Add map for upstream overlay on RPi5
+  Create empty upstream overlay to silence firmware warnings.
+---
+ arch/arm/boot/dts/overlays/Makefile           |  1 +
+ arch/arm/boot/dts/overlays/cma64-overlay.dts  | 40 +++++++++++++++++++
+ .../dts/overlays/enable-bt-pi5-overlay.dts    | 13 ++++++
+ arch/arm/boot/dts/overlays/overlay_map.dts    | 24 +++++++++++
+ arch/arm/boot/dts/overlays/upstream-pi5.dts   |  9 +++++
+ .../dts/overlays/vc4-kms-v3d-pi5-overlay.dts  |  4 +-
+ 6 files changed, 89 insertions(+), 2 deletions(-)
+ create mode 100644 arch/arm/boot/dts/overlays/cma64-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/enable-bt-pi5-overlay.dts
+ create mode 100644 arch/arm/boot/dts/overlays/upstream-pi5.dts
+
+diff --git a/arch/arm/boot/dts/overlays/Makefile b/arch/arm/boot/dts/overlays/Makefile
+index e142a7d..88bfdc2 100644
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -44,6 +44,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	cirrus-wm5102.dtbo \
+ 	cm-swap-i2c0.dtbo \
+ 	cma.dtbo \
++	cma64.dtbo \
+ 	crystalfontz-cfa050_pi_m.dtbo \
+ 	cutiepi-panel.dtbo \
+ 	dacberry400.dtbo \
+diff --git a/arch/arm/boot/dts/overlays/cma64-overlay.dts b/arch/arm/boot/dts/overlays/cma64-overlay.dts
+new file mode 100644
+index 0000000..92d25d3
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/cma64-overlay.dts
+@@ -0,0 +1,40 @@
++/*
++ * cma64.dts
++ */
++
++/dts-v1/;
++/plugin/;
++
++/*
++ * "cma" overlay uses  #size-cells = <1>. Raspberry Pi 5 uses #size-cells = <2>
++ */
++
++/ {
++	compatible = "brcm,bcm2712";
++
++	fragment@0 {
++		target = <&cma>;
++		frag0: __overlay__ {
++			/*
++			 * The default size when using this overlay is 256 MB
++			 * and should be kept as is for backwards
++			 * compatibility.
++			 */
++			size = <0x0 0x10000000>;
++		};
++	};
++
++	__overrides__ {
++		cma-512 = <&frag0>,"size:4=0x20000000";
++		cma-448 = <&frag0>,"size:4=0x1c000000";
++		cma-384 = <&frag0>,"size:4=0x18000000";
++		cma-320 = <&frag0>,"size:4=0x14000000";
++		cma-256 = <&frag0>,"size:4=0x10000000";
++		cma-192 = <&frag0>,"size:4=0x0C000000";
++		cma-128 = <&frag0>,"size:4=0x08000000";
++		cma-96  = <&frag0>,"size:4=0x06000000";
++		cma-64  = <&frag0>,"size:4=0x04000000";
++		cma-size = <&frag0>,"size:4"; /* in bytes, 4MB aligned */
++		cma-default = <0>,"-0";
++	};
++};
+diff --git a/arch/arm/boot/dts/overlays/enable-bt-pi5-overlay.dts b/arch/arm/boot/dts/overlays/enable-bt-pi5-overlay.dts
+new file mode 100644
+index 0000000..21cb04d
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/enable-bt-pi5-overlay.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/{
++	compatible = "brcm,bcm2712";
++
++	fragment@0 {
++		target = <&bluetooth>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm/boot/dts/overlays/overlay_map.dts b/arch/arm/boot/dts/overlays/overlay_map.dts
+index 6fa5979..6d6c5e6 100644
+--- a/arch/arm/boot/dts/overlays/overlay_map.dts
++++ b/arch/arm/boot/dts/overlays/overlay_map.dts
+@@ -20,6 +20,16 @@
+ 		deprecated = "use i2c-sensor,bmp085";
+ 	};
+ 
++	cma {
++		bcm2835;
++		bcm2711;
++		bcm2712 = "cma64";
++	};
++
++	cma64 {
++		bcm2712;
++	};
++
+ 	cm-swap-i2c0 {
+ 		bcm2835;
+ 		bcm2711;
+@@ -53,6 +63,15 @@
+ 		bcm2712;
+ 	};
+ 
++	enable-bt {
++		bcm2711;
++		bcm2712 = "enable-bt-pi5";
++	};
++
++	enable-bt-pi5 {
++		bcm2712;
++	};
++
+ 	hifiberry-adc8x {
+ 		bcm2712;
+ 	};
+@@ -462,6 +481,7 @@
+ 	upstream {
+ 		bcm2835;
+ 		bcm2711 = "upstream-pi4";
++		bcm2712 = "upstream-pi5";
+ 	};
+ 
+ 	upstream-aux-interrupt {
+@@ -472,6 +492,10 @@
+ 		bcm2711;
+ 	};
+ 
++	upstream-pi5 {
++		bcm2712;
++	};
++
+ 	vc4-fkms-v3d {
+ 		bcm2835;
+ 		bcm2711 = "vc4-fkms-v3d-pi4";
+diff --git a/arch/arm/boot/dts/overlays/upstream-pi5.dts b/arch/arm/boot/dts/overlays/upstream-pi5.dts
+new file mode 100644
+index 0000000..e0e0a04
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/upstream-pi5.dts
+@@ -0,0 +1,9 @@
++//
++
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "brcm,bcm2712";
++};
+diff --git a/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts b/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts
+index f887818..e9504a7 100644
+--- a/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/vc4-kms-v3d-pi5-overlay.dts
+@@ -1,9 +1,9 @@
+ // SPDX-License-Identifier: GPL-2.0
+ 
+-#include "cma-overlay.dts"
++#include "cma64-overlay.dts"
+ 
+ &frag0 {
+-	size = <(64*1024*1024)>;
++	size = <0x0 (64*1024*1024)>;
+ };
+ 
+ / {
+-- 
+2.51.0
+

--- a/artifacts/dtb/raspberrypi/patches/0010-0001-dts-bcm2712-Extend-PCIe-range-to-encompass-firmware-.patch
+++ b/artifacts/dtb/raspberrypi/patches/0010-0001-dts-bcm2712-Extend-PCIe-range-to-encompass-firmware-.patch
@@ -1,0 +1,75 @@
+From f2e32117838c0b095c9789ac74597ee3b0f3c13d Mon Sep 17 00:00:00 2001
+From: Andrea della Porta <andrea.porta@suse.com>
+Date: Fri, 6 Feb 2026 16:54:32 +0100
+Subject: [PATCH] dts: bcm2712: Extend PCIe range to encompass shared SRAM
+
+The actual DT nodes from PCIe root complex to the RP1 endpoint
+device do not include the sram shared memory range. While this
+shared memory is not used yet, there's an error from mmio-sram
+driver which cannot map the entire range.
+
+Extend the range accordingly.
+
+Signed-off-by: Andrea della Porta <andrea.porta@suse.com>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts  | 2 +-
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi | 2 +-
+ arch/arm64/boot/dts/broadcom/bcm2712.dtsi         | 2 +-
+ arch/arm64/boot/dts/broadcom/rp1.dtsi             | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+index bd6f747..1ed6b4a 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
+@@ -140,7 +140,7 @@ rp1_target: &pcie2 {
+ 	// This is the RP1 peripheral space
+ 	ranges = <0x00 0x40000000
+ 		  0x01 0x00 0x00000000
+-		  0x00 0x00400000>;
++		  0x00 0x00410000>;
+ 
+ 	dma-ranges =
+ 	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index beff401..c3dc847 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -127,7 +127,7 @@ rp1_target: &pcie2 {
+ 	// This is the RP1 peripheral space
+ 	ranges = <0x00 0x40000000
+ 		  0x01 0x00 0x00000000
+-		  0x00 0x00400000>;
++		  0x00 0x00410000>;
+ 
+ 	dma-ranges =
+ 	// inbound RP1 1x_xxxxxxxx -> PCIe 1x_xxxxxxxx
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+index 58d8790..e5f7cb3 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+@@ -552,7 +552,7 @@
+ 
+ 			dma-ranges =
+ 				/* 4MiB, 32-bit, non-prefetchable at PCIe 00_0000_0000 */
+-				<0x02000000 0x00 0x00000000 0x1f 0x00000000 0x00 0x00400000>,
++				<0x02000000 0x00 0x00000000 0x1f 0x00000000 0x00 0x00410000>,
+ 				/* 64GiB, 64-bit, prefetchable at PCIe 10_0000_0000 */
+ 				<0x43000000 0x10 0x00000000 0x00 0x00000000 0x10 0x00000000>,
+ 				/* 4KiB, 64-bit, non-prefetchable at PCIe ff_ffff_f000 MIP0 */
+diff --git a/arch/arm64/boot/dts/broadcom/rp1.dtsi b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+index a401aae..4411ae5 100644
+--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
++++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+@@ -9,7 +9,7 @@
+ 	#size-cells = <2>;
+ 	ranges = <0x01 0x00 0x00000000
+ 		  0x02000000 0x00 0x00000000
+-		  0x0 0x400000>;
++		  0x0 0x410000>;
+ 	interrupt-controller;
+ 	#interrupt-cells = <2>;
+ 
+-- 
+2.51.0
+

--- a/artifacts/dtb/raspberrypi/pkg.yaml
+++ b/artifacts/dtb/raspberrypi/pkg.yaml
@@ -1,0 +1,58 @@
+name: dtb-raspberrypi
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - network: default
+    sources:
+      - url: https://github.com/raspberrypi/linux/archive/refs/tags/{{ .raspberrypi_kernel_version }}.tar.gz
+        destination: raspberrypi-linux.tar.gz
+        sha256: "{{ .raspberrypi_kernel_sha256 }}"
+        sha512: "{{ .raspberrypi_kernel_sha512 }}"
+    prepare:
+      - |
+        tar xf raspberrypi-linux.tar.gz --strip-components=1
+        rm raspberrypi-linux.tar.gz
+
+        for patch in $(find /pkg/patches -type f -name "*.patch" | sort); do
+          echo "Applying patch $patch"
+          patch -p1 < $patch || (echo "Failed to apply patch $patch" && exit 1)
+        done
+
+        mkdir -p arch/arm/boot/dts/overlays/
+        cp -av /pkg/overlays/* arch/arm/boot/dts/overlays/
+  - build:
+      - |
+        mkdir -p out/overlays
+
+        export DTC_FLAGS="-R 4 -p 0x1000 -@ -H epapr"
+        for dts in arch/arm64/boot/dts/broadcom/bcm27*dts; do
+            # bcm2712-d-rpi-5-b.dts -> bcm2712-d-rpi-5-b
+            target=$(basename ${dts%*.dts})
+            cpp -nostdinc -I include -I arch -undef -x assembler-with-cpp -I scripts/dtc/include-prefixes/ -D__DTS__ -DFIRMWARE_UPDATED -P $dts -o out/$target.dts
+            dtc -O dtb $DTC_FLAGS -o out/$target.dtb out/$target.dts
+        done
+
+        export DTC_FLAGS="-R 0 -p 0 -@ -H epapr"
+        for dts in arch/arm/boot/dts/overlays/*dts; do
+            # disable-v3d-overlay.dts -> disable-v3d
+            target=$(basename ${dts%*.dts})
+            target=${target%*-overlay}
+            cpp -nostdinc -I include -I arch -undef -x assembler-with-cpp -I scripts/dtc/include-prefixes/ -D__DTS__ -DFIRMWARE_UPDATED -P $dts -o out/overlays/$target.dts
+            dtc -O dtb $DTC_FLAGS -o out/overlays/$target.dtbo out/overlays/$target.dts
+        done
+
+        # Match the names firmware wants.
+        mv out/overlays/hat_map.dtbo out/overlays/hat_map.dtb
+        mv out/overlays/overlay_map.dtbo out/overlays/overlay_map.dtb
+    install:
+      - |
+        mkdir -p /rootfs/overlays
+
+        cp -av out/bcm2712*.dtb /rootfs/
+        cp -av out/overlays/*.dtbo out/overlays/*.dtb arch/arm/boot/dts/overlays/README /rootfs/overlays/
+        cp -av COPYING /rootfs/COPYING.linux
+finalize:
+  - from: /rootfs
+    to: /

--- a/artifacts/raspberrypi-firmware/pkg.yaml
+++ b/artifacts/raspberrypi-firmware/pkg.yaml
@@ -3,19 +3,16 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
-    platform: linux/arm64
-    from: /
-    to: /kernel
 steps:
   - sources:
       - url: https://github.com/raspberrypi/firmware/archive/refs/tags/{{ .raspberrypi_firmware_version }}.tar.gz
-        destination: raspberrypi-firmware.tar.xz
+        destination: raspberrypi-firmware.tar.gz
         sha256: "{{ .raspberrypi_firmware_sha256 }}"
         sha512: "{{ .raspberrypi_firmware_sha512 }}"
     prepare:
       - |
-        tar xf raspberrypi-firmware.tar.xz --strip-components=1
+        tar xf raspberrypi-firmware.tar.gz --strip-components=1
+        rm raspberrypi-firmware.tar.gz
     install:
       - |
         mkdir -p /rootfs/artifacts/arm64/firmware/boot
@@ -24,7 +21,6 @@ steps:
         rm /rootfs/artifacts/arm64/firmware/boot/kernel*
         # At least now downstream Pi 5 dts are not compatible with mainline
         rm /rootfs/artifacts/arm64/firmware/boot/bcm2712*
-        cp /kernel/dtb/broadcom/bcm2712* /rootfs/artifacts/arm64/firmware/boot/
 finalize:
   - from: /rootfs
     to: /rootfs

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -5,6 +5,11 @@ dependencies:
   - stage: rpi_5
   - stage: revpi_generic
   - stage: raspberrypi-firmware
+  # TODO: replace with Linux ones once all the boards are supported upstream
+  - stage: dtb-raspberrypi
+    platform: linux/arm64
+    from: /
+    to: /rootfs/artifacts/rpi_5
   - stage: revpi-firmware
     platform: linux/arm64
   - stage: u-boot

--- a/installers/rpi_5/src/main.go
+++ b/installers/rpi_5/src/main.go
@@ -41,7 +41,8 @@ func (i *RpiInstaller) GetOptions(extra rpiOptions) (overlay.Options, error) {
 }
 
 func (i *RpiInstaller) Install(options overlay.InstallOptions[rpiOptions]) error {
-	err := copy.Dir(filepath.Join(options.ArtifactsPath, "arm64/firmware/boot"), filepath.Join(options.MountPrefix, "/boot/EFI"))
+	// Pi 5 does not need any binaries from raspberrypi-firmware, so only install dtbs (built from Linux) and U-Boot
+	err := copy.Dir(filepath.Join(options.ArtifactsPath, "rpi_5"), filepath.Join(options.MountPrefix, "/boot/EFI"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Enable Raspberry Pi 5 Rev 1.1 (D0 stepping) boards to boot up with ethernet working.
Replicates openSUSE [`raspberrypi-firmware-dt`](https://build.opensuse.org/package/show/hardware:boot/raspberrypi-firmware-dt) package to get dts patches and overlays work properly.

guidance from https://github.com/siderolabs/talos/issues/12748#issuecomment-3893476433 https://github.com/siderolabs/talos/issues/12748#issuecomment-3899034804

closes https://github.com/siderolabs/talos/issues/12748