### PR TITLE
rpi_5: build dedicated u-boot with RP1 support instead of reusing rpi_generic

### DIFF
--- a/installers/rpi_5/src/main.go
+++ b/installers/rpi_5/src/main.go
@@ -47,7 +47,7 @@ func (i *RpiInstaller) Install(options overlay.InstallOptions[rpiOptions]) error
 		return err
 	}
 
-	err = copy.File(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rpi_generic/u-boot.bin"), filepath.Join(options.MountPrefix, "/boot/EFI/u-boot.bin"))
+	err = copy.File(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rpi_5/u-boot.bin"), filepath.Join(options.MountPrefix, "/boot/EFI/u-boot.bin"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #96
rpi_5 currently reuses the rpi_generic u-boot binary (built with rpi_arm64_defconfig), which has no RP1 southbridge support. This causes boot failures on D0-stepping Pi 5 boards (board revision e04171) -- either a hang at the u-boot splash screen or a kernel panic in brcmuart_init -> pinctrl_bind_pins -> brcmstb_pinconf_set -- and prevents NVMe boot entirely on any Pi 5, regardless of stepping.
configs/rpi_5_defconfig and the RP1 driver code do not exist in real upstream u-boot yet, even at the version already pinned in this repo's Pkgfile (2026.01), so this adds a second, independent build step rather than just switching the existing step's defconfig target.
Adds artifacts/u-boot/patches/rpi_5/ (23 patches enabling RP1 clock/GPIO/MFD/reset/PCIe drivers and NVMe support, plus rpi_5_defconfig), a new build step in artifacts/u-boot/pkg.yaml producing arm64/u-boot/rpi_5/u-boot.bin, and a one-line change to installers/rpi_5/src/main.go to use it. The existing rpi_generic step and output are completely untouched.
Patches ported from talos-rpi5/u-boot (tag v2025.04-rpi5-3), originally authored by Oleksii Moisieiev and Volodymyr Babchuk (EPAM Systems) as an RFC series to the U-Boot mailing list: https://lists.denx.de/pipermail/u-boot/2025-February/581083.html
One patch (0015, HACK: set bar configuration for RP1 driver) is explicitly labeled as a workaround by its own author. Upstream U-Boot maintainers have separately indicated they'd prefer RP1's PCIe config handled via dynamic overlay loading rather than this static approach (see the RFC thread above). It's a known, acknowledged tradeoff, not a long-term-correct fix -- but it's what makes NVMe boot work today.
Two related efforts worth knowing about: Torsten Duwe posted a cleaner, forward-ported resend of this same work in October 2025 (https://lists.denx.de/pipermail/u-boot/2025-October/600297.html), which may be a better long-term source. Separately, SUSE has landed a more mature, non-hacky u-boot port for Pi 5, but as of their announcement it only supports SD card boot -- no PCIe/NVMe support yet -- so it doesn't cover this use case.
Validated: all 23 patches apply cleanly against the exact upstream u-boot version already pinned in Pkgfile; the patched tree builds successfully with rpi_5_defconfig; the resulting binary has been running in production for multiple days across 4 Pi 5 boards (all board revision e04171) as Talos Kubernetes worker nodes, booting from NVMe.
Testing gap: only tested on D0-stepping hardware. Per the request in #96, D1-stepping testing would be needed before merge -- I don't have D1 hardware myself. If anyone in the community can test, that would close the remaining gap.