### PR TITLE
chore: bump RPI firmware

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,9 +4,9 @@ format: v1alpha2
 
 vars:
   # renovate: datasource=github-tags depName=raspberrypi/firmware
-  raspberrypi_firmware_version: 1.20250915
-  raspberrypi_firmware_sha256: 55a5d58c59bf7171562f1f1289c638e97e2b8d90374084887bfe5fc83e57cb1d
-  raspberrypi_firmware_sha512: 33120c901c59fbcd267427dce5fd8f174d32476bfae76744697f6729151d66054c6f0bd54f29c3b715c1492a52724fe2973a6adbf31cfb79f1c82dd94983cf77
+  raspberrypi_firmware_version: 1.20260521
+  raspberrypi_firmware_sha256: b900de58571920a306ab2d1296500499d0744451dbefda0c76b79e652bb71cb7
+  raspberrypi_firmware_sha512: 92e9680a521cfb3b7824ed5a50026414ace49765b568b66cd919eb973a46ecf13743fe2e11145a7d28036591705b36198c3cc2765a132f32caf2fe22206c3818
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=u-boot/u-boot
   uboot_version: 2026.01


### PR DESCRIPTION
Hi Sidero Labs team!

While testing SATA/NVMe attachments I found out that some things are buggy that are already fixed upstream. 

With this PR Im bumping the deps since the current `pcie-32bit-dma-pi5.dtbo` makes MSI-dependent devices on the RPi 5 external PCIe connector unusable.

I see that the renovate bots PR (#33) hasnt been merged since 2024 eventhough it is bringing in lots of fixes for RPI5. I also see that updates to deps are done manually and not via renovate.

If you are open to it I could take a look at the config and check why e.g. it doesnt update the `raspberrypi_firmware_sha256`or `raspberrypi_firmware_sha512` in  the Pkgfile

